### PR TITLE
Replace = with ==

### DIFF
--- a/xl2fpcore/XL2FPCore.fs
+++ b/xl2fpcore/XL2FPCore.fs
@@ -29,7 +29,7 @@ let expandApplications(pre: List<Dictionary<AST.Address,double>>) : FPProperty o
                     Seq.map (fun kvp ->
                         let name = (NormalizeAddr kvp.Key).ToString()
                         let value = kvp.Value.ToString()
-                        "(= " + name + " " + value + ")"
+                        "(== " + name + " " + value + ")"
                     ) |>
                     Seq.toList
                 "(and " + String.Join(" ", exprs) + ")"


### PR DESCRIPTION
Fixes bug in with = versus ==. The standard FPCore equality operator is ==, not =